### PR TITLE
Add toolbar option hover background color

### DIFF
--- a/src/striveneditor.js
+++ b/src/striveneditor.js
@@ -160,6 +160,9 @@ export default class StrivenEditor {
         this.toolbarOptions.forEach(optionEl => {
             // Assign Styles
             // optionEl.style.padding = "0 10px";
+            optionEl.style.display = 'inline-block';
+            optionEl.onmouseenter = () => optionEl.style.background = "#88BE7E";
+            optionEl.onmouseleave = () => optionEl.style.background = 'white';
             optionEl.style.cursor = "pointer";
             optionEl.style.userSelect = "none";
 


### PR DESCRIPTION
Adds a background color to the toolbar options on hover. I went with this approach because changing the SVG fill color on hover overrides the icon color when it is the selected option. Below is the color I went with for the hover color. I used your send button's color and lightened it a bit to let the icon show through. Attempt to solve [#33](https://github.com/striven-erp/striven-editor/issues/33) 

<img width="590" alt="Screen Shot 2019-10-15 at 5 19 36 PM" src="https://user-images.githubusercontent.com/38336076/66876720-0e7d9e80-ef70-11e9-863d-1e56b951e24b.png">
<img width="593" alt="Screen Shot 2019-10-15 at 5 20 52 PM" src="https://user-images.githubusercontent.com/38336076/66876757-28b77c80-ef70-11e9-8838-43e502b48fbc.png">


