### PR TITLE
Adds .destroy() method

### DIFF
--- a/src/striveneditor.js
+++ b/src/striveneditor.js
@@ -94,6 +94,7 @@ export default class StrivenEditor {
             };
         }
 
+        this.saveInitialEditorHTML(el);
         this.initEditor(el);
         this.initResponsive();
         this.initOverflow();
@@ -1318,5 +1319,23 @@ export default class StrivenEditor {
 
         // Blink engine detection
         this.isBlink = (this.isChrome || this.isOpera) && !!window.CSS;
+    }
+
+    /**
+     * This method is used to keep a ref of the initial HTML state of the editor
+     * @param el
+     */
+    saveInitialEditorHTML(el) {
+        if (el) {
+            this.initialEditorHTML = el.outerHTML;
+            this.el = el;
+        }
+    }
+
+    /**
+     * This method will destroy the editor customizations
+     */
+    destroy() {
+        this.el.outerHTML = this.initialEditorHTML;
     }
 }

--- a/src/striveneditor.js
+++ b/src/striveneditor.js
@@ -1336,6 +1336,10 @@ export default class StrivenEditor {
      * This method will destroy the editor customizations
      */
     destroy() {
-        this.el.outerHTML = this.initialEditorHTML;
+        if (this.el) {
+            this.el.outerHTML = this.initialEditorHTML;
+            this.el = undefined;
+            this.initialEditorHTML = undefined;
+        }
     }
 }


### PR DESCRIPTION
If applied, this pull request will add a new `.destroy()` method so we can destroy the editor instance and set the original HTML state of the editor element.

#54