### PR TITLE
#50 Feature/react integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,16 @@ new KoStrivenEditor(ko);
 We other optional react integration
 ```js
 import React from 'react';
-import {render} from 'react-dom';
 import {createEditor} from '@striven-erp/striven-editor/dist/react-integration'
 
 const Editor = createEditor({toolbarBottom: true, minimal: true,});
 
-render( <Editor />, document.getElementById('app'))
+const App = () => {
+    return <>
+        <p>Happy editing 🎉</p>
+        <Editor />
+    </>
+}
 ```
 Note, that the editor options can't be changed, when mounted. Therefore, we currently do not support setting them via props.
 If you want to change them, create a new editor component.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,49 @@ new KoStrivenEditor(ko);
 <div data-bind="striveneditor: editorConfig" />
 ```
 
+## React Integration
+We other optional react integration
+```js
+import React from 'react';
+import {render} from 'react-dom';
+import {createEditor} from '@striven-erp/striven-editor/dist/react-integration'
+
+const Editor = createEditor({toolbarBottom: true, minimal: true,});
+
+render( <Editor />, document.getElementById('app'))
+```
+Note, that the editor options can't be changed, when mounted. Therefore, we currently do not support setting them via props.
+If you want to change them, create a new editor component.
+
+You can pass a ref to the component to access the underlying editor instance.
+We also provide a memoized hook for functional components, if you want to change editor options,
+but take care of handling editor state as needed.
+```js
+import React, {useRef, useLayoutEffect} from 'react';
+import {useEditor} from '@striven-erp/striven-editor/dist/react-integration'
+
+function MinimizableEditor({minimal}) {
+    let editor = useRef(null);
+    let content = useRef(null);
+    let EditorComponent = useEditor({minimal, toolbarBottom: true}, [minimal]);
+
+    useLayoutEffect(
+        () => {
+            // set previous content
+            editor.current.setContent(content.current);
+            let prevEditor = editor.current;
+            return () => {
+                // backup old content
+                content.current = prevEditor.getContent();
+            }
+        },
+        [EditorComponent]
+    );
+
+    return <EditorComponent ref={editor} />
+}
+```
+
 ## Fetching Meta Data on Link Insertions
 
 To fetch meta data from links that are pasted or inserted into the editor, you must set up a back end utility to fetch the data and send it back to your client. For a node server, we recommend using [metascraper](https://metascraper.js.org/#/) on your server. See the example below for setting this up with express.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@striven-erp/striven-editor",
-  "version": "2.0.2",
+  "version": "2.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3090,7 +3090,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3111,12 +3112,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3131,17 +3134,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3258,7 +3264,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3270,6 +3277,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3284,6 +3292,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3291,12 +3300,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3315,6 +3326,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3395,7 +3407,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3407,6 +3420,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3492,7 +3506,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3528,6 +3543,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3547,6 +3563,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3590,12 +3607,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,16 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
+      "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0",
+        "esutils": "^2.0.0"
+      }
+    },
     "@babel/helper-call-delegate": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
@@ -383,6 +393,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+      "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
@@ -633,6 +652,46 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+      "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
+      "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx": "^7.3.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
+      "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
+      "integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
     "@babel/plugin-transform-regenerator": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
@@ -765,6 +824,19 @@
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.5.0"
+      }
+    },
+    "@babel/preset-react": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.6.3.tgz",
+      "integrity": "sha512-07yQhmkZmRAfwREYIQgW0HEwMY9GBJVuPY4Q12UC72AbfaawuupVWa8zQs2tlL+yun45Nv/1KreII/0PLfEsgA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
     "@babel/template": {
@@ -4231,8 +4303,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "jsesc": {
       "version": "2.5.2",
@@ -4337,7 +4408,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -4832,8 +4902,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5253,6 +5322,17 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "optional": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -5398,6 +5478,23 @@
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       }
+    },
+    "react": {
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.10.2.tgz",
+      "integrity": "sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==",
+      "optional": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-is": {
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==",
+      "optional": true
     },
     "readable-stream": {
       "version": "2.3.6",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "dependencies": {},
   "optionalDependencies": {
-    "react": "^16.10.2"
+    "react": "^16.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/core": "^7.6.0",
     "@babel/plugin-transform-modules-umd": "^7.2.0",
     "@babel/preset-env": "^7.6.0",
+    "@babel/preset-react": "^7.6.3",
     "babel-loader": "^8.0.6",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
@@ -53,5 +54,8 @@
     "webpack": "^4.40.2",
     "webpack-cli": "^3.3.9"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "optionalDependencies": {
+    "react": "^16.10.2"
+  }
 }

--- a/src/react-integration.jsx
+++ b/src/react-integration.jsx
@@ -1,0 +1,22 @@
+import StrivenEditor from "./striveneditor";
+import React, {useLayoutEffect, useRef, forwardRef} from "react";
+
+export function createEditor(options) {
+    return forwardRef((props, ref) => {
+        let container = useRef(null);
+        /** @type {{current: StrivenEditor|null}}  **/
+        let editor = useRef(null);
+
+        useLayoutEffect(
+            () => {
+                editor.current = new StrivenEditor(container.current, options);
+                if (ref) {
+                    ref.current = editor.current;
+                }
+            },
+            []
+        );
+
+        return <div ref={container} />
+    });
+}

--- a/src/react-integration.jsx
+++ b/src/react-integration.jsx
@@ -24,7 +24,7 @@ export function createEditor(options) {
     });
 }
 
-export function useMemoizedEditor(options, input) {
+export function useEditor(options, input) {
     return useMemo(
         () => createEditor(options),
         input

--- a/src/react-integration.jsx
+++ b/src/react-integration.jsx
@@ -1,8 +1,8 @@
 import StrivenEditor from "./striveneditor";
-import React, {useLayoutEffect, useRef, forwardRef} from "react";
+import React, {useLayoutEffect, useRef, useCallback, forwardRef} from "react";
 
 export function createEditor(options) {
-    return forwardRef((props, ref) => {
+    return forwardRef(({defaultContent}, ref) => {
         let container = useRef(null);
         /** @type {{current: StrivenEditor|null}}  **/
         let editor = useRef(null);
@@ -12,6 +12,9 @@ export function createEditor(options) {
                 editor.current = new StrivenEditor(container.current, options);
                 if (ref) {
                     ref.current = editor.current;
+                }
+                if (defaultContent !== undefined) {
+                    editor.current.setContent(defaultContent);
                 }
             },
             []

--- a/src/react-integration.jsx
+++ b/src/react-integration.jsx
@@ -1,5 +1,5 @@
 import StrivenEditor from "./striveneditor";
-import React, {useLayoutEffect, useRef, useCallback, forwardRef} from "react";
+import React, {useLayoutEffect, useRef, useCallback, useMemo, forwardRef} from "react";
 
 export function createEditor(options) {
     return forwardRef(({defaultContent}, ref) => {
@@ -22,4 +22,11 @@ export function createEditor(options) {
 
         return <div ref={container} />
     });
+}
+
+export function useMemoizedEditor(options, input) {
+    return useMemo(
+        () => createEditor(options),
+        input
+    )
 }

--- a/src/react-integration.jsx
+++ b/src/react-integration.jsx
@@ -1,5 +1,5 @@
 import StrivenEditor from "./striveneditor";
-import React, {useLayoutEffect, useRef, useCallback, useMemo, forwardRef} from "react";
+import React, {useLayoutEffect, useRef, useMemo, forwardRef} from "react";
 
 export function createEditor(options) {
     return forwardRef(({defaultContent}, ref) => {
@@ -9,12 +9,9 @@ export function createEditor(options) {
 
         useLayoutEffect(
             () => {
-                editor.current = new StrivenEditor(container.current, options);
-                if (ref) {
-                    ref.current = editor.current;
-                }
+                ref.current = new StrivenEditor(container.current, options);
                 if (defaultContent !== undefined) {
-                    editor.current.setContent(defaultContent);
+                    ref.current.setContent(defaultContent);
                 }
             },
             []

--- a/src/react-integration.jsx
+++ b/src/react-integration.jsx
@@ -1,12 +1,20 @@
+import './striveneditor.css';
+
 import StrivenEditor from "./striveneditor";
 import React, {useLayoutEffect, useRef, useMemo, forwardRef} from "react";
 
+/**
+ * Creates an editor component that mounts with the given option.
+ * If you pass a ref to the component, it binds to the wrapped StrivenEditor instance
+ *
+ * @param {Object} options - accepted by StrivenEditor
+ * @returns {React.ComponentType<{readonly defaultContent?: *}>}
+ */
 export function createEditor(options) {
     return forwardRef(({defaultContent}, ref) => {
-        let container = useRef(null);
-        /** @type {{current: StrivenEditor|null}}  **/
-        let editor = useRef(null);
 
+        let container = useRef(null);
+        // on mount create a striven editor from given options and set the ref
         useLayoutEffect(
             () => {
                 ref.current = new StrivenEditor(container.current, options);
@@ -21,6 +29,12 @@ export function createEditor(options) {
     });
 }
 
+/**
+ *
+ * @param {Object} options - options passed to StrivenEditor
+ * @param {Array} input - see input of useMemo
+ * @returns {React.ComponentType<{readonly, defaultContent?: *}>}
+ */
 export function useEditor(options, input) {
     return useMemo(
         () => createEditor(options),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        presets: ['@babel/preset-env'],
+                        presets: ['@babel/preset-env', '@babel/preset-react'],
                         plugins: ['@babel/plugin-transform-modules-umd']
                     }
                 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,5 +54,13 @@ module.exports = {
             },
             extractComments: true,
         })]
+    },
+    externals: {
+        react: {
+            commonjs: 'react',
+            commonjs2: 'react',
+            amd: 'react',
+            root: 'React',
+        }
     }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,8 @@ module.exports = {
         index: './src/index.js',
         striveneditor: './src/striveneditor.js',
         'ko-striveneditor': './src/ko-striveneditor.js',
-        'vue-striveneditor': './src/vue-striveneditor.vue'
+        'vue-striveneditor': './src/vue-striveneditor.vue',
+        'react-integration': './src/react-integration.jsx',
     },
     output: {
         path: path.resolve(__dirname, "dist"),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
     module: {
         rules: [
             {
-                test: /\.m?js$/,
+                test: /\.m?jsx?$/,
                 exclude: /(node_modules|bower_components)/,
                 use: {
                     loader: 'babel-loader',


### PR DESCRIPTION
This pr introduces optional react integration requested in #50 

unlike knockout and vue integration, we require react as dependency in order to create the root div to mount the editor on.

If we add the react utils to our index.js, we could wrap them in a try/catch block, to create an optional dependency export, but this leads to unuseful warnings for users that don't develop with react.

Therefore, I've decided to not at the react integration to index.js for now.

Also note, that since the options are not meant to be changed on a given instance, I've decided against a base solution that would receive the options as props and instead provided a method, that creates a component based on a set of options.

I've also provided an hook and example, if users want to change options of their editor component.
We could add a more elaborate component that supports option change based on the example, but should discuss details regarding transfer of content, files and what else.

See the README.md for more. :)